### PR TITLE
fail silently on invalid json

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -312,7 +312,12 @@ export class NpmWorker {
     const content = textEditor.getText();
     const reportMessages = [];
 
-    const dependencies = this.parseJson(content);
+    let dependencies = [];
+    try {
+      dependencies = this.parseJson(content);
+    } catch (ex) {
+      console.error(ex);
+    }
     const reports = dependencies
       .filter(dependency => !canRangeBeIgnored(dependency.version))
       .map(dependency =>


### PR DESCRIPTION
When typing in package.json and it becomes invalid this packages displays multiple errors.

- Log error in console but don't display an error message