### PR TITLE
add latestOnly setting

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -46,5 +46,11 @@ export default {
     "type": "integer",
     "default": 10,
     "minimum": 0
+  },
+  "latestOnly": {
+    "title": "Only up to @latest version",
+    "description": "Only show versions up to @latest",
+    "type": "boolean",
+    "default": false
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,10 @@ export default {
     this.subscriptions.add(
       atom.config.observe('atom-npm-outdated.streamReporting', (enableStreamReporting) => this.npmWorker.enableStreamReporting = enableStreamReporting)
     );
+
+    this.subscriptions.add(
+      atom.config.observe('atom-npm-outdated.latestOnly', (latestOnly) => this.npmWorker.latestOnly = latestOnly)
+    );
   },
 
   deactivate() {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -36,6 +36,7 @@ export class NpmWorker {
     this.runningRequestSize = 0;
     this.requestStack = [];
     this.enableStreamReporting = true;
+    this.latestOnly = false;
   }
 
   /**
@@ -155,13 +156,25 @@ export class NpmWorker {
   /**
    * Extract the valuable versions according to the configuration
    * @param {String[]} versions Full list of versions
+   * @param {String} latest Latest version
    * @return {String[]} List of valuable versions ordered ASC
    */
-  extractValuableVersions(versions) {
+  extractValuableVersions(versions, latest) {
     return versions
       .filter(version => {
         const prerelease = semver.prerelease(version);
-        return !prerelease || this.prereleases.includes(prerelease[0]);
+        if (prerelease && !this.prereleases.includes(prerelease[0])) {
+          return false;
+        }
+
+        if (this.latestOnly && latest) {
+          const gtLatest = semver.gt(version, latest);
+          if (gtLatest) {
+            return false;
+          }
+        }
+
+        return true;
       })
       .sort(semver.compare);
   }
@@ -258,7 +271,7 @@ export class NpmWorker {
       .then((currentPackage) => ({
         name: dependency.name,
         version: dependency.version,
-        availableVersions: this.extractValuableVersions(currentPackage.versions)
+        availableVersions: this.extractValuableVersions(currentPackage.versions, currentPackage["dist-tags"].latest)
       }));
   }
 


### PR DESCRIPTION
Adds a setting to only update up to `@latest` version

![image](https://user-images.githubusercontent.com/97994/61399982-e27d4f00-a894-11e9-8809-c9869be28aa7.png)

This option will remove `@next` versions from being suggested as the latest version

![image](https://user-images.githubusercontent.com/97994/61400263-80711980-a895-11e9-96e1-2bbf820532e1.png)

![image](https://user-images.githubusercontent.com/97994/61400292-954dad00-a895-11e9-8da7-8c40ea00dd4f.png)
